### PR TITLE
Renamed FILE_STORAGE_PATH to comply with regexp-rules

### DIFF
--- a/src/main/java/com/rest/szz/entities/Storage.java
+++ b/src/main/java/com/rest/szz/entities/Storage.java
@@ -12,20 +12,20 @@ import com.rest.szz.git.*;
 
 public class Storage {
 	
-	private Path FILE_STORAGE_PATH = Paths.get(
+	private Path fileStoragePath = Paths.get(
 			System.getProperty("user.dir")
 	);
 	
 	{
 		// Create working directory if it does not exist.
-		FILE_STORAGE_PATH.toFile().mkdirs();
+		fileStoragePath.toFile().mkdirs();
 	}
 	
 	private Git git = null;
 	private final Pattern pGit = Pattern.compile(".+\\.git$");
 	
 	public Storage(String projectName) {
-		FILE_STORAGE_PATH = Paths.get(
+		fileStoragePath = Paths.get(
 				System.getProperty("user.dir") 
 				);
 	}
@@ -42,7 +42,7 @@ public class Storage {
 		List<Transaction> result = new ArrayList<Transaction>();
 		Matcher mGit = pGit.matcher(url.toString());
 		if(mGit.find()) {
-			this.git = new Git(FILE_STORAGE_PATH, url);
+			this.git = new Git(fileStoragePath, url);
 			try {
 				this.git.cloneRepository();
 				this.git.pullUpdates();


### PR DESCRIPTION
FIX: Renamed the field "FILE_STORAGE_PATH" to match the regular expression '^[a-z][a-zA-Z0-9]*$'

OTHER: Build fails, even in original version.
Error message: 
> Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:exec (default-cli) on project SZZRest: Command execution failed. Process exited with an error: 1 (Exit value: 1) -> [Help 1]
